### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Found a very interesting dataset on Kaggle on [customer visits](https://www.kaggle.com/hassanaftab/customer-visits-data) predicition of a shopping mall. Though I'd play with the dataset to see what can be done - it's a good feature engineering and modeling challenge.
+Found a very interesting dataset on Kaggle on [customer visits](https://www.kaggle.com/hassanaftab/customer-visits-data) prediction of a shopping mall. Though I'd play with the dataset to see what can be done - it's a good feature engineering and modeling challenge.
 
 # Customer-Visits
 The data-set provides information about shopping mall visits of 300k customers over the course of 143 weeks. Each line represents one customer - the first column contains a unique customer identifier and the second column contains a vector of the day numbers he/she visited the mall. 


### PR DESCRIPTION
## Summary
- fix typo in README: `predicition` → `prediction`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684f38ba86d88329a20476b34b6b8094