### PR TITLE
Fix early_stop_round parameter name

### DIFF
--- a/Customer Visits - Prediction iterations.Rmd
+++ b/Customer Visits - Prediction iterations.Rmd
@@ -106,7 +106,7 @@ xgbcv <- xgboost::xgb.cv(params = params,
                 showsd = TRUE, 
                 stratified = TRUE, 
                 print_every_n = 10, 
-                early_stop_round = 20, 
+                early_stopping_rounds = 20, 
                 maximize = FALSE, 
                 prediction = TRUE)
 
@@ -182,7 +182,7 @@ xgbcv <- xgboost::xgb.cv(params = params,
                 showsd = TRUE, 
                 stratified = TRUE, 
                 print_every_n = 10, 
-                early_stop_round = 20, 
+                early_stopping_rounds = 20, 
                 maximize = FALSE, 
                 prediction = TRUE)
 
@@ -258,7 +258,7 @@ xgbcv <- xgboost::xgb.cv(params = params,
                 showsd = TRUE, 
                 stratified = TRUE, 
                 print_every_n = 10, 
-                early_stop_round = 20, 
+                early_stopping_rounds = 20, 
                 maximize = FALSE, 
                 prediction = TRUE)
 
@@ -334,7 +334,7 @@ xgbcv <- xgboost::xgb.cv(params = params,
                 showsd = TRUE, 
                 stratified = TRUE, 
                 print_every_n = 10, 
-                early_stop_round = 20, 
+                early_stopping_rounds = 20, 
                 maximize = FALSE, 
                 prediction = TRUE)
 


### PR DESCRIPTION
## Summary
- update `Customer Visits - Prediction iterations.Rmd` to use the correct `early_stopping_rounds` parameter

## Testing
- `Rscript -e "sessionInfo()"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684f38bfa8548329b579e909ffeee09b